### PR TITLE
Add node label selector instead of ignore node label selector

### DIFF
--- a/label_selector.go
+++ b/label_selector.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Labels is a map of labels.
+type Labels map[string]string
+
+func (l Labels) String() string {
+	labels := make([]string, 0, len(l))
+	for k, v := range l {
+		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return strings.Join(labels, ",")
+}
+
+// Set parses a pod selector string and adds it to the list.
+func (l Labels) Set(value string) error {
+	labelsStrs := strings.Split(value, ",")
+	for _, labelStr := range labelsStrs {
+		kv := strings.Split(labelStr, "=")
+		if len(kv) < 1 || len(kv) > 2 {
+			return fmt.Errorf("invalid pod selector format")
+		}
+
+		val := ""
+		if len(kv) == 2 {
+			val = kv[1]
+		}
+
+		l[kv[0]] = val
+	}
+
+	return nil
+}
+
+// IsCumulative always return true because it's allowed to call Set multiple
+// times.
+func (l Labels) IsCumulative() bool {
+	return true
+}

--- a/label_selector_test.go
+++ b/label_selector_test.go
@@ -1,0 +1,53 @@
+package main
+
+import "testing"
+
+func TestLabelsString(t *testing.T) {
+	labels := Labels(map[string]string{
+		"master": "true",
+	})
+	expected := "master=true"
+
+	if labels.String() != expected {
+		t.Errorf("expected %s, got %s", expected, labels.String())
+	}
+
+}
+
+func TestSetLabelsValue(t *testing.T) {
+	for _, tc := range []struct {
+		msg   string
+		value string
+		valid bool
+	}{
+		{
+			msg:   "test valid labels",
+			value: "master=true,worker=false",
+			valid: true,
+		},
+		{
+			msg:   "test invalid labels",
+			value: "master=true=false",
+			valid: false,
+		},
+	} {
+		t.Run(tc.msg, func(t *testing.T) {
+			labels := Labels(map[string]string{})
+			err := labels.Set(tc.value)
+			if err != nil && tc.valid {
+				t.Errorf("should not fail: %s", err)
+			}
+
+			if err == nil && !tc.valid {
+				t.Error("expected failure")
+			}
+		})
+	}
+}
+
+func TestLabelsIsCumulative(t *testing.T) {
+	labels := Labels(map[string]string{})
+	if !labels.IsCumulative() {
+		t.Error("expected IsCumulative = true")
+	}
+}


### PR DESCRIPTION
It was a bit weird to blacklist nodes instead of just white listing them and fetching nodes with a label selector on the server side. replace the flag `--ignore-node-label` with `--node-selector`.