### PR TITLE
Fix initializing labels map

### DIFF
--- a/label_selector.go
+++ b/label_selector.go
@@ -19,6 +19,10 @@ func (l Labels) String() string {
 
 // Set parses a pod selector string and adds it to the list.
 func (l Labels) Set(value string) error {
+	if l == nil {
+		l = Labels(map[string]string{})
+	}
+
 	labelsStrs := strings.Split(value, ",")
 	for _, labelStr := range labelsStrs {
 		kv := strings.Split(labelStr, "=")

--- a/label_selector_test.go
+++ b/label_selector_test.go
@@ -32,7 +32,7 @@ func TestSetLabelsValue(t *testing.T) {
 		},
 	} {
 		t.Run(tc.msg, func(t *testing.T) {
-			labels := Labels(map[string]string{})
+			var labels Labels
 			err := labels.Set(tc.value)
 			if err != nil && tc.valid {
 				t.Errorf("should not fail: %s", err)
@@ -46,7 +46,7 @@ func TestSetLabelsValue(t *testing.T) {
 }
 
 func TestLabelsIsCumulative(t *testing.T) {
-	labels := Labels(map[string]string{})
+	var labels Labels
 	if !labels.IsCumulative() {
 		t.Error("expected IsCumulative = true")
 	}


### PR DESCRIPTION
When using the `--node-selector` flag the labels map was not initialized causing assignment to a nil map panic. Fixed by initializing the map in case it was not.

This also moves the kubernetes client code out of `NewController` so it's easier to test locally.