### PR TITLE
Add retries for updating node taints

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -60,6 +60,12 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  name = "github.com/cenkalti/backoff"
+  packages = ["."]
+  revision = "2ea60e5f094469f9e65adb9cd103795b73ae743e"
+  version = "v2.0.0"
+
+[[projects]]
   name = "github.com/ghodss/yaml"
   packages = ["."]
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
@@ -424,6 +430,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "533b3e1f54f4f088aefd6204e5bdc24ed43e9f605f561c9646c2086cebd74d88"
+  inputs-digest = "26832df13f066c0a33f654c7c2b5456fe8a9a20dc520ec130f6c7c5b1a6d5b79"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/controller.go
+++ b/controller.go
@@ -33,12 +33,12 @@ type NodeController struct {
 	configMap             string
 	namespace             string
 	nodeReadyHooks        []Hook
-	nodeStartUpObeserver  NodeStartUpObeserver
+	nodeStartUpObserver   NodeStartUpObserver
 	taintNodeNotReadyName string
 }
 
 // NewNodeController initializes a new NodeController.
-func NewNodeController(client kubernetes.Interface, selectors []*PodSelector, nodeSelectorLabels map[string]string, taintNodeNotReadyName string, interval time.Duration, configMap string, hooks []Hook, nodeStartUpObeserver NodeStartUpObeserver) (*NodeController, error) {
+func NewNodeController(client kubernetes.Interface, selectors []*PodSelector, nodeSelectorLabels map[string]string, taintNodeNotReadyName string, interval time.Duration, configMap string, hooks []Hook, nodeStartUpObserver NodeStartUpObserver) (*NodeController, error) {
 	controller := &NodeController{
 		Interface:             client,
 		selectors:             selectors,
@@ -46,7 +46,7 @@ func NewNodeController(client kubernetes.Interface, selectors []*PodSelector, no
 		interval:              interval,
 		configMap:             configMap,
 		nodeReadyHooks:        hooks,
-		nodeStartUpObeserver:  nodeStartUpObeserver,
+		nodeStartUpObserver:   nodeStartUpObserver,
 		taintNodeNotReadyName: taintNodeNotReadyName,
 	}
 
@@ -219,9 +219,9 @@ func (n *NodeController) setNodeReady(node *v1.Node, ready bool) error {
 				"node":   updatedNode.ObjectMeta.Name,
 			}).Info("")
 
-			if n.nodeStartUpObeserver != nil {
+			if n.nodeStartUpObserver != nil {
 				// observe node startup duration
-				n.nodeStartUpObeserver.ObeserveNode(*updatedNode)
+				n.nodeStartUpObserver.ObserveNode(*updatedNode)
 			}
 
 			// trigger hooks on node ready.

--- a/controller.go
+++ b/controller.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	log "github.com/sirupsen/logrus"
-
 	"k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -19,6 +20,7 @@ const (
 	// the pod selector definition is defined.
 	ConfigMapSelectorsKey   = "pod_selectors"
 	serviceAccountNamespace = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	maxConflictRetries      = 50
 )
 
 // NodeController updates the readiness taint of nodes based on expected
@@ -170,60 +172,80 @@ func (n *NodeController) nodeReady(node *v1.Node) (bool, error) {
 // setNodeReady sets node taint macthing ready value. E.g. sets NotReady taint
 // if ready is false, and removes the taint (if exists) when ready is true.
 func (n *NodeController) setNodeReady(node *v1.Node, ready bool) error {
-	// if ready, remove notReady taint if exists on the node
-	if ready {
-		var newTaints []v1.Taint
-		for _, taint := range node.Spec.Taints {
-			if taint.Key != n.taintNodeNotReadyName {
-				newTaints = append(newTaints, taint)
-			}
+	setNodeReadiness := func() error {
+		updatedNode, err := n.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
+		if err != nil {
+			return backoff.Permanent(err)
 		}
 
-		if len(newTaints) != len(node.Spec.Taints) {
-			node.Spec.Taints = newTaints
-			_, err := n.CoreV1().Nodes().Update(node)
-			if err != nil {
-				return err
-			}
-			log.WithFields(log.Fields{
-				"action": "removed",
-				"taint":  n.taintNodeNotReadyName,
-				"node":   node.ObjectMeta.Name,
-			}).Info("")
-
-			if n.nodeStartUpObeserver != nil {
-				// observe node startup duration
-				n.nodeStartUpObeserver.ObeserveNode(*node)
-			}
-
-			// trigger hooks on node ready.
-			for _, hook := range n.nodeReadyHooks {
-				err := hook.Trigger(node.Spec.ProviderID)
-				if err != nil {
-					log.Errorf("Failed to trigger hook '%s': %v", hook.Name(), err)
+		// if ready, remove notReady taint if exists on the node
+		if ready {
+			var newTaints []v1.Taint
+			for _, taint := range updatedNode.Spec.Taints {
+				if taint.Key != n.taintNodeNotReadyName {
+					newTaints = append(newTaints, taint)
 				}
 			}
-		}
-	} else { // else add the taint if the node is not ready
-		if !hasTaint(node, n.taintNodeNotReadyName) {
-			taint := v1.Taint{
-				Key:    n.taintNodeNotReadyName,
-				Effect: v1.TaintEffectNoSchedule,
+
+			if len(newTaints) != len(updatedNode.Spec.Taints) {
+				updatedNode.Spec.Taints = newTaints
+				_, err := n.CoreV1().Nodes().Update(updatedNode)
+				if err != nil {
+					// automatically retry if there was a conflicting update.
+					serr, ok := err.(*apiErrors.StatusError)
+					if ok && serr.Status().Reason == metav1.StatusReasonConflict {
+						return err
+					}
+					return backoff.Permanent(err)
+				}
+				log.WithFields(log.Fields{
+					"action": "removed",
+					"taint":  n.taintNodeNotReadyName,
+					"node":   updatedNode.ObjectMeta.Name,
+				}).Info("")
+
+				if n.nodeStartUpObeserver != nil {
+					// observe node startup duration
+					n.nodeStartUpObeserver.ObeserveNode(*updatedNode)
+				}
+
+				// trigger hooks on node ready.
+				for _, hook := range n.nodeReadyHooks {
+					err := hook.Trigger(updatedNode.Spec.ProviderID)
+					if err != nil {
+						log.Errorf("Failed to trigger hook '%s': %v", hook.Name(), err)
+					}
+				}
 			}
-			node.Spec.Taints = append(node.Spec.Taints, taint)
-			_, err := n.CoreV1().Nodes().Update(node)
-			if err != nil {
-				return err
+		} else { // else add the taint if the node is not ready
+			if !hasTaint(updatedNode, n.taintNodeNotReadyName) {
+				taint := v1.Taint{
+					Key:    n.taintNodeNotReadyName,
+					Effect: v1.TaintEffectNoSchedule,
+				}
+				updatedNode.Spec.Taints = append(updatedNode.Spec.Taints, taint)
+				_, err := n.CoreV1().Nodes().Update(updatedNode)
+				if err != nil {
+					// automatically retry if there was a conflicting update.
+					serr, ok := err.(*apiErrors.StatusError)
+					if ok && serr.Status().Reason == metav1.StatusReasonConflict {
+						return err
+					}
+					return backoff.Permanent(err)
+				}
+				log.WithFields(log.Fields{
+					"action": "added",
+					"taint":  n.taintNodeNotReadyName,
+					"node":   updatedNode.ObjectMeta.Name,
+				}).Info("")
 			}
-			log.WithFields(log.Fields{
-				"action": "added",
-				"taint":  n.taintNodeNotReadyName,
-				"node":   node.ObjectMeta.Name,
-			}).Info("")
 		}
+
+		return nil
 	}
 
-	return nil
+	backoffCfg := backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), maxConflictRetries)
+	return backoff.Retry(setNodeReadiness, backoffCfg)
 }
 
 // getConfig gets a selector config from a config map.

--- a/controller.go
+++ b/controller.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cenkalti/backoff"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
-	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -192,8 +192,7 @@ func (n *NodeController) setNodeReady(node *v1.Node, ready bool) error {
 				_, err := n.CoreV1().Nodes().Update(updatedNode)
 				if err != nil {
 					// automatically retry if there was a conflicting update.
-					serr, ok := err.(*apiErrors.StatusError)
-					if ok && serr.Status().Reason == metav1.StatusReasonConflict {
+					if errors.IsConflict(err) {
 						return err
 					}
 					return backoff.Permanent(err)
@@ -227,8 +226,7 @@ func (n *NodeController) setNodeReady(node *v1.Node, ready bool) error {
 				_, err := n.CoreV1().Nodes().Update(updatedNode)
 				if err != nil {
 					// automatically retry if there was a conflicting update.
-					serr, ok := err.(*apiErrors.StatusError)
-					if ok && serr.Status().Reason == metav1.StatusReasonConflict {
+					if errors.IsConflict(err) {
 						return err
 					}
 					return backoff.Permanent(err)

--- a/main.go
+++ b/main.go
@@ -75,9 +75,9 @@ func main() {
 		hooks = append(hooks, NewASGLifecycleHook(awsSession, config.ASGLifecycleHook))
 	}
 
-	var startupObeserver NodeStartUpObeserver
+	var startupObserver NodeStartUpObserver
 	if config.EnableNodeStartUpMetrics {
-		startupObeserver, err = NewASGNodeStartUpObserver(awsSession)
+		startupObserver, err = NewASGNodeStartUpObserver(awsSession)
 		if err != nil {
 			log.Fatalf("Failed to setup observer: %v", err)
 		}
@@ -108,7 +108,7 @@ func main() {
 		config.Interval,
 		config.ConfigMap,
 		hooks,
-		startupObeserver,
+		startupObserver,
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Adds retries for setting the node taint. This is needed because it updates the whole node object, which may have changed in between.

Fix #3